### PR TITLE
Update deps and expose new option `removeEmptyKeyValuePairs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Use Typeset.logback and configure the various options:
                 <!-- The following are the default values. -->
                 <prettyPrint>false</prettyPrint>
                 <removeNullKeyValuePairs>true</removeNullKeyValuePairs>
+                <removeEmptyKeyValuePairs>false</removeEmptyKeyValuePairs>
                 <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
                 <escapeNonAsciiCharacters>false</escapeNonAsciiCharacters>
                 <sortKeysLexicographically>false</sortKeysLexicographically>

--- a/deps.edn
+++ b/deps.edn
@@ -1,22 +1,21 @@
 {:paths ["src" "target/classes"]
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.3"}
-        metosin/jsonista {:mvn/version "0.3.8"}}
+ :deps {org.clojure/clojure {:mvn/version "1.11.4"}
+        ch.qos.logback/logback-classic {:mvn/version "1.5.6"}
+        metosin/jsonista {:mvn/version "0.3.10"}}
  :deps/prep-lib {:alias :build
                  :fn compile
                  :ensure "target/classes"}
  :aliases
  {;; clj -X:test
   :test  {:extra-paths ["test"]
-          :extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}
+          :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                        clj-time/clj-time {:mvn/version "0.15.2"}
-                       com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.15.2"}
-                       com.fasterxml.jackson.datatype/jackson-datatype-joda {:mvn/version "2.15.2"}}
+                       com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.17.2"}
+                       com.fasterxml.jackson.datatype/jackson-datatype-joda {:mvn/version "2.17.2"}}
           :exec-fn kaocha.runner/exec-fn}
   ;; clj -T:build ...
   :build {:extra-paths ["build"]
-          :deps {io.github.clojure/tools.build
-                 {:git/tag "v0.10.0", :git/sha "3a2c484"}
+          :deps {io.github.clojure/tools.build {:git/tag "v0.10.5", :git/sha "2a21b7a"}
                  slipset/deps-deploy {:mvn/version "0.2.2"}}
           :ns-default build}
   ;; clj -M:lint

--- a/src/com/kroo/typeset/logback/JsonLayout.clj
+++ b/src/com/kroo/typeset/logback/JsonLayout.clj
@@ -18,6 +18,7 @@
    :exposes-methods {start superStart, stop superStop}
    :methods [[setPrettyPrint [Boolean] void]
              [setRemoveNullKeyValuePairs [Boolean] void]
+             [setRemoveEmptyKeyValuePairs [Boolean] void]
              [setTimestampFormat [String] void]
              [setEscapeNonAsciiCharacters [Boolean] void]
              [setSortKeysLexicographically [Boolean] void]
@@ -76,6 +77,7 @@
   [[] (volatile! (let [opts (map->JsonLayoutOpts
                              {:pretty             false
                               :strip-nils         true
+                              :strip-empties      false
                               :date-format        "yyyy-MM-dd'T'HH:mm:ss'Z'"
                               :escape-non-ascii   false
                               :order-by-keys      false
@@ -220,59 +222,36 @@
 ;;; -------------------------------------
 ;;; Expose Logback configuration options.
 
-(defmacro ^:private set-opt! [this opt]
-  `(vswap! (.state ~this) assoc ~(keyword opt) ~opt))
-
 (defn- update-opt+mapper
   "Update an option in the option map and builds a new Jackson ObjectMapper."
   ^JsonLayoutOpts [opts k v]
   (let [opts (assoc opts k v)]
     (assoc opts :object-mapper (new-object-mapper opts))))
 
-(defn -setPrettyPrint [this pretty-print?]
-  (vswap! (.state this) update-opt+mapper
-          :pretty pretty-print?))
+(defmacro ^:private defopt-mapper [method-name key]
+  `(defn ~method-name [this# value#]
+     (vswap! (.state this#) update-opt+mapper ~key value#)))
 
-(defn -setRemoveNullKeyValuePairs [this remove-nil-kvs?]
-  (vswap! (.state this) update-opt+mapper
-          :strip-nils remove-nil-kvs?))
+(defmacro ^:private defopt [method-name key]
+  `(defn ~method-name [this# value#]
+     (vswap! (.state this#) assoc ~key value#)))
 
-(defn -setTimestampFormat [this timestamp-format]
-  (vswap! (.state this) update-opt+mapper
-          :date-format timestamp-format))
-
-(defn -setEscapeNonAsciiCharacters [this escape-non-ascii?]
-  (vswap! (.state this) update-opt+mapper
-          :escape-non-ascii escape-non-ascii?))
-
-(defn -setSortKeysLexicographically [this sort-keys?]
-  (vswap! (.state this) update-opt+mapper
-          :order-by-keys sort-keys?))
+(defopt-mapper -setPrettyPrint :pretty)
+(defopt-mapper -setRemoveNullKeyValuePairs :strip-nils)
+(defopt-mapper -setRemoveEmptyKeyValuePairs :strip-empties)
+(defopt-mapper -setTimestampFormat :date-format)
+(defopt-mapper -setEscapeNonAsciiCharacters :escape-non-ascii)
+(defopt-mapper -setSortKeysLexicographically :order-by-keys)
 
 (defn -setJacksonModules [this modules]
   (vswap! (.state this) update-opt+mapper
           :modules (reify-jackson-modules modules)))
 
-(defn -setAppendLineSeparator [this append-newline]
-  (set-opt! this append-newline))
-
-(defn -setIncludeLoggerContext [this include-logger-ctx]
-  (set-opt! this include-logger-ctx))
-
-(defn -setIncludeLevelValue [this include-level-val]
-  (set-opt! this include-level-val))
-
-(defn -setIncludeMdc [this include-mdc]
-  (set-opt! this include-mdc))
-
-(defn -setFlattenMdc [this flatten-mdc]
-  (set-opt! this flatten-mdc))
-
-(defn -setIncludeMarkers [this include-markers]
-  (set-opt! this include-markers))
-
-(defn -setIncludeException [this include-exception]
-  (set-opt! this include-exception))
-
-(defn -setIncludeExData [this include-ex-data]
-  (set-opt! this include-ex-data))
+(defopt -setAppendLineSeparator :append-newline)
+(defopt -setIncludeLoggerContext :include-logger-ctx)
+(defopt -setIncludeLevelValue :include-level-val)
+(defopt -setIncludeMdc :include-mdc)
+(defopt -setFlattenMdc :flatten-mdc)
+(defopt -setIncludeMarkers :include-markers)
+(defopt -setIncludeException :include-exception)
+(defopt -setIncludeExData :include-ex-data)

--- a/src/com/kroo/typeset/logback/JsonLayout.clj
+++ b/src/com/kroo/typeset/logback/JsonLayout.clj
@@ -5,6 +5,7 @@
             [clojure.string :as str])
   (:import (ch.qos.logback.classic.spi ILoggingEvent IThrowableProxy ThrowableProxy ThrowableProxyUtil)
            (ch.qos.logback.core CoreConstants)
+           (clojure.lang Reflector)
            (java.time Instant)
            (java.util HashMap List Map Map$Entry)
            (org.slf4j Marker)
@@ -41,14 +42,11 @@
                            include-markers
                            include-exception
                            include-ex-data
-                           exception-as-str
                            modules
                            object-mapper])
 
 (defn- reify-jackson-module [module]
-  (clojure.lang.Reflector/invokeConstructor
-   (-> module symbol resolve)
-   (to-array [])))
+  (Reflector/invokeConstructor (-> module symbol resolve) (to-array [])))
 
 (defn- reify-jackson-modules [modules]
   (into []
@@ -228,7 +226,7 @@
   (let [opts (assoc opts k v)]
     (assoc opts :object-mapper (new-object-mapper opts))))
 
-(defmacro ^:private defopt-mapper [method-name key]
+(defmacro ^:private defopt-json [method-name key]
   `(defn ~method-name [this# value#]
      (vswap! (.state this#) update-opt+mapper ~key value#)))
 
@@ -236,12 +234,12 @@
   `(defn ~method-name [this# value#]
      (vswap! (.state this#) assoc ~key value#)))
 
-(defopt-mapper -setPrettyPrint :pretty)
-(defopt-mapper -setRemoveNullKeyValuePairs :strip-nils)
-(defopt-mapper -setRemoveEmptyKeyValuePairs :strip-empties)
-(defopt-mapper -setTimestampFormat :date-format)
-(defopt-mapper -setEscapeNonAsciiCharacters :escape-non-ascii)
-(defopt-mapper -setSortKeysLexicographically :order-by-keys)
+(defopt-json -setPrettyPrint :pretty)
+(defopt-json -setRemoveNullKeyValuePairs :strip-nils)
+(defopt-json -setRemoveEmptyKeyValuePairs :strip-empties)
+(defopt-json -setTimestampFormat :date-format)
+(defopt-json -setEscapeNonAsciiCharacters :escape-non-ascii)
+(defopt-json -setSortKeysLexicographically :order-by-keys)
 
 (defn -setJacksonModules [this modules]
   (vswap! (.state this) update-opt+mapper


### PR DESCRIPTION
Updated dependencies, refactored code and exposed a new config option available with the latest [metosin/jsonista](https://github.com/metosin/jsonista) lib: [`:strip-empties`](https://github.com/metosin/jsonista/releases/tag/0.3.10) -> `removeEmptyKeyValuePairs`.